### PR TITLE
MC folding bug

### DIFF
--- a/src/rna_folding/rna_folder.py
+++ b/src/rna_folding/rna_folder.py
@@ -47,7 +47,6 @@ class RNAFolder(ABC):
         self.twobody_penalty = 500000
         self.pseudo_factor = 0.5
         self.no_stem_penalty = 500000
-        self.best_score = 1e10
 
     def _fold_prep(self, sequence):
         self.nseq = sequence

--- a/src/rna_folding/rna_folders/classical_mc.py
+++ b/src/rna_folding/rna_folders/classical_mc.py
@@ -100,9 +100,10 @@ class MC(RNAFolder):
             self.config.args.random_seed
         )  # need for random.sample reproducibility
         self.stem_idx = random.sample(
-            range(1, self.len_stem_list), math.ceil((self.len_stem_list) / 5)
+            range(1, self.len_stem_list), math.floor((self.len_stem_list) / 5)
         )
         self.score = self._calc_score(self.stem_idx)
+        self.best_score = self.score
 
     def _calc_score(self, idx):
         """

--- a/tests/test_cases/test_random_seed.py
+++ b/tests/test_cases/test_random_seed.py
@@ -419,7 +419,7 @@ def test_METRO_DefaultSeed():
     assert opt.list_seqs == opt2.list_seqs
 
 
-def test_Fold_MC():
+def test_fold_MC():
     """
     Test to verify the same minimum energy and secondary structure are reached
     on repeated runs of fold.py


### PR DESCRIPTION
Resolves #59 

Refactors the MC folder a little bit. 

- Removes second loop
- Changes parameters for initial structure guess
- updates min free energy and secondary structure after every iteration
- adds random seed call before random sample to maintain reproducibility on subsequent calls of the MC folder
- adds test for the above point