### PR TITLE
Energy no stems

### DIFF
--- a/src/analysis/analyses/compute_energy.py
+++ b/src/analysis/analyses/compute_energy.py
@@ -62,7 +62,7 @@ class ComputeEnergy(Analysis):
         if self.active_stem_indices != []:
             self.score = self.rna_folder_obj._calc_score(self.active_stem_indices)
         else:
-            self.score = self.rna_folder_obj.twobody_penalty
+            self.score = self.rna_folder_obj.no_stem_penalty
         self.config.log.info("Sequence: " + self.rna_folder_obj.nseq)
         self.config.log.info("Sequence Length: " + str(self.rna_folder_obj.n))
         self.config.log.info("Energy of input structure: " + str(self.score))

--- a/src/analysis/analyses/k_neighbor_energy.py
+++ b/src/analysis/analyses/k_neighbor_energy.py
@@ -28,7 +28,7 @@ class KNeighborEnergySearch(ComputeEnergy):
         if self.active_stem_indices != []:
             self.energies = [self.rna_folder_obj._calc_score(self.active_stem_indices)]
         else:
-            self.energies = [self.rna_folder_obj.twobody_penalty]
+            self.energies = [self.rna_folder_obj.no_stem_penalty]
         self._analyze()
 
     def _analyze(self):
@@ -45,7 +45,7 @@ class KNeighborEnergySearch(ComputeEnergy):
             if new_stems != []:
                 new_energy = self.rna_folder_obj._calc_score(new_stems)
             else:
-                new_energy = self.rna_folder_obj.twobody_penalty
+                new_energy = self.rna_folder_obj.no_stem_penalty
 
             if new_energy < 0:
                 valid_neighbor_count += 1


### PR DESCRIPTION
Added cases in both ```compute_energy``` and ```k_neighbor_energy``` analysis so that a structure with no stems will output the correct high energy.