### PR TITLE
simplify detection of stem overlaps

### DIFF
--- a/src/codon_opt/codon_optimizer.py
+++ b/src/codon_opt/codon_optimizer.py
@@ -29,7 +29,9 @@ class CodonOptimizer(ABC):
     def __init__(self, config: Config):
         self.config = config
         random.seed(self.config.args.random_seed)
-        self.config.log.debug("Input protein sequence length: " + str(len(self.config.protein_sequence)))
+        self.config.log.debug(
+            "Input protein sequence length: " + str(len(self.config.protein_sequence))
+        )
         self.codon_optimize_step = 0
         self.convergence_count = 0
         (
@@ -278,7 +280,14 @@ class CodonOptimizer(ABC):
         self.list_seqs = [self._convert_ints_to_codons(s) for s in self.members]
         if fold_sequences:
             for s in range(len(self.list_seqs)):
-                self.config.log.debug("Generation number: " + str(self.codon_optimize_step) + ". Population number " + str(s) + " of " + str(self.config.args.population_size))
+                self.config.log.debug(
+                    "Generation number: "
+                    + str(self.codon_optimize_step)
+                    + ". Population number "
+                    + str(s)
+                    + " of "
+                    + str(self.config.args.population_size)
+                )
                 self._fold_rna(self.list_seqs[s])
                 self.config.log.debug("Completed structure prediction.\n")
                 self.energies[s] = self.folder.best_score

--- a/src/database/database.py
+++ b/src/database/database.py
@@ -83,7 +83,9 @@ class Database(object):
                 f"""CREATE TABLE MFE_SEQUENCES (index_key {primary_key_type} PRIMARY KEY,
                 sim_key INT, sequences VARCHAR, secondary_structure VARCHAR)"""
             )
-            config.log.debug("Created database tables in " + config.args.output + "\n\n")
+            config.log.debug(
+                "Created database tables in " + config.args.output + "\n\n"
+            )
         except:
             config.db.rollback()
             config.log.debug("Adding data to existing tables within database.\n\n")

--- a/src/rna_folding/rna_folder.py
+++ b/src/rna_folding/rna_folder.py
@@ -56,7 +56,10 @@ class RNAFolder(ABC, RNAStructure, StructureIO, StructureConvert):
         self.config.log.debug("Sequence Length: " + str(self.n))
         self._gen_stems()
         self.len_stem_list = len(self.stems)
-        self.config.log.debug("Finished generating stems. Number of possible stems: " + str(self.len_stem_list))
+        self.config.log.debug(
+            "Finished generating stems. Number of possible stems: "
+            + str(self.len_stem_list)
+        )
         self._compute_h_and_J()
         self.config.log.debug("Finished generating Hamiltonian matrices.")
 

--- a/src/rna_structure/structure.py
+++ b/src/rna_structure/structure.py
@@ -25,29 +25,23 @@ class RNAStructure(object):
         ]
 
     def _detect_stem_overlap(self, stem1, stem2):
+        """
+        Function to detect if a base is involved in two stems which is
+        a stem overlap. Returns True if the stems overlap and False
+        otherwise.
+
+        """
         from src.rna_structure.structure_convert import StructureConvert
 
         struct_convert = StructureConvert()
         pairs1 = struct_convert._stem_to_pair_list(stem1)
         pairs2 = struct_convert._stem_to_pair_list(stem2)
 
-        keep1 = [
-            pair1
-            for pair1 in pairs1
-            if not any(_ in pair1 for _ in np.array(pairs2).flatten())
-        ]
-        keep2 = [
-            pair2
-            for pair2 in pairs2
-            if not any(_ in pair2 for _ in np.array(pairs1).flatten())
-        ]
-
-        if len(keep1) == len(pairs1) and len(keep2) == len(pairs2):
-            # No overlap
-            return False
-        else:
-            # Overlap
-            return True
+        for pair1 in pairs1:
+            for pair2 in pairs2:
+                if pair1[0] in pair2 or pair1[1] in pair2:
+                    return True
+        return False
 
     def _is_pseudo(self, stem1, stem2):
         first = np.argmin([stem1[0], stem2[0]])

--- a/tests/test_cases/test_analyses.py
+++ b/tests/test_cases/test_analyses.py
@@ -362,6 +362,7 @@ def test_classify_stems():
         and analysis.overlaps == 0
     )
 
+
 def test_contact_order():
     """
     Test computation of contact order for a given input structure


### PR DESCRIPTION
Previously, detecting stems took N_1 x N_2 operations where N_i is the length of the stems being considered. The size of the stem tends to be fairly small (< 100) so the full number of operations is typically less than a few thousand. Additionally, using a for loop allows for early termination if a base is detected in both stems. We don't necessarily care how many bases overlap, just that there is an overlap. This makes N_1 x N_2 operations only the worst case scenario.

Some formatting changes also occurred.